### PR TITLE
Terraform remote provisioner and Ansible autorun (+ new Ansible dynamic inventory)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .vscode/
-app-creds.sh
+app-cred*.sh
 **.pem

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,7 +1,7 @@
 [defaults]
 remote_user = ubuntu
-interpreter_python = /usr/bin/python3
-inventory = hosts
+private_key_file = /home/ubuntu/ilifu.pem
+host_key_checking = False
 
 [ssh_connection]
 pipelining = true

--- a/ansible/openstack.yml
+++ b/ansible/openstack.yml
@@ -1,0 +1,10 @@
+plugin: openstack.cloud.openstack
+expand_hostvars: no
+private: yes
+fail_on_errors: yes
+all_projects: no
+cache: no
+keyed_groups:
+  - key: openstack.metadata.ansible_group_name
+    prefix: ''
+    separator: ''

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: k8s_control_plane,k8s_worker_plane
   become: yes
   roles:
     - name: kubernetes

--- a/terraform/floatingips.tf
+++ b/terraform/floatingips.tf
@@ -5,4 +5,76 @@ resource "openstack_networking_floatingip_v2" "fip" {
 resource "openstack_compute_floatingip_associate_v2" "fip_assoc" {
   floating_ip = openstack_networking_floatingip_v2.fip.address
   instance_id = openstack_compute_instance_v2.control-plane.id
+
+  # Copy Private Key to Ansible node
+  provisioner "file" {
+
+    connection {
+      type     = "ssh"
+      user     = "ubuntu"
+      host     = openstack_networking_floatingip_v2.fip.address
+      private_key = "${file("../ilifu.pem")}"
+    }
+
+    source = "../ilifu.pem"
+    destination = "/home/ubuntu/ilifu.pem"
+  }
+
+  # Copy Ansible directory to target (TESTING, SHOULD BE GIT FOR PROD)
+  provisioner "file" {
+
+    connection {
+      type     = "ssh"
+      user     = "ubuntu"
+      host     = openstack_networking_floatingip_v2.fip.address
+      private_key = "${file("../ilifu.pem")}"
+    }
+
+    source = "../ansible"
+    destination = "/home/ubuntu/ilifu-kubernetes-ansible"
+  }
+  
+  # Copy OpenStack App Creds to Ansible node
+  provisioner "file" {
+
+    connection {
+      type     = "ssh"
+      user     = "ubuntu"
+      host     = openstack_networking_floatingip_v2.fip.address
+      private_key = "${file("../ilifu.pem")}"
+    }
+
+    source = "../app-cred.sh"
+    destination = "/home/ubuntu/app-cred.sh"
+  }
+
+  # Copy run script to Ansible node
+  provisioner "file" {
+
+    connection {
+      type     = "ssh"
+      user     = "ubuntu"
+      host     = openstack_networking_floatingip_v2.fip.address
+      private_key = "${file("../ilifu.pem")}"
+    }
+
+    source = "./k8s_ansible.sh"
+    destination = "/home/ubuntu/k8s_ansible.sh"
+  }
+
+  # Execute run script for Ansible
+  provisioner "remote-exec" {
+
+    connection {
+      type     = "ssh"
+      user     = "ubuntu"
+      host     = openstack_networking_floatingip_v2.fip.address
+      private_key = "${file("../ilifu.pem")}"
+    }
+
+    inline = [
+      "chmod +x /home/ubuntu/k8s_ansible.sh",
+      "/home/ubuntu/k8s_ansible.sh"
+    ]
+  }
 }

--- a/terraform/k8s_ansible.sh
+++ b/terraform/k8s_ansible.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+sudo sed -i 's/nova.clouds.archive.ubuntu.com/ubuntu.mirror.ac.za/g' /etc/apt/sources.list
+sudo apt update && sudo apt install -y git python3-venv
+chmod 600 /home/ubuntu/ilifu.pem
+source ~/ilifu-kubernetes-ansible/app-cred.sh
+source ~/ansible/bin/activate
+cd ~; python3 -m venv ansible
+pip3 install -U pip
+pip3 install 'ansible>=2.9' 'openstacksdk<=0.98.999'
+cd ~/ilifu-kubernetes-ansible
+ansible-galaxy install -r requirements.yml
+ansible-playbook -i openstack.yml playbook.yml

--- a/terraform/k8s_ansible.sh
+++ b/terraform/k8s_ansible.sh
@@ -4,8 +4,8 @@ sudo sed -i 's/nova.clouds.archive.ubuntu.com/ubuntu.mirror.ac.za/g' /etc/apt/so
 sudo apt update && sudo apt install -y git python3-venv
 chmod 600 /home/ubuntu/ilifu.pem
 source ~/ilifu-kubernetes-ansible/app-cred.sh
-source ~/ansible/bin/activate
 cd ~; python3 -m venv ansible
+source ~/ansible/bin/activate
 pip3 install -U pip
 pip3 install 'ansible>=2.9' 'openstacksdk<=0.98.999'
 cd ~/ilifu-kubernetes-ansible


### PR DESCRIPTION
This commit triggers a Terraform file and remote provisioners in order to place secrets (app creds, private cert) and run files (k8s_ansible.sh).  Once the bootstrap of the environment is done, the terraform will deploy the initial ansible to prepare the nodes for kubeadm install.

For the ansible side, I've created an openstack dynamic inventory and changed the `playbook.yml` to match the appropriate groups that are collected from the OpenStack VM metadata (instead of matching all). The `ansible.cfg` file now looks for the private key of the VMs from a fixed directory that the terraform will ensure exists on the controller node.

For now the kubeadm install is done manually and this has to be migrated to kubespray or something down the line.

**It also copies the ansible directory to the controller node. This is to allow more rapid testing for now.** 

 